### PR TITLE
add support to separate multiple questions

### DIFF
--- a/edx_jsme/templates/problem/jsme.yaml
+++ b/edx_jsme/templates/problem/jsme.yaml
@@ -4,6 +4,7 @@ metadata:
     markdown: !!null
 data: |
     <problem>
+      <question>
       <p>
         A molecular structure problem lets the user use the JSME editor
         component to draw a new molecule or update an existing drawing and then
@@ -76,4 +77,5 @@ data: |
           </p>
         </div>
       </solution>
+      </question>
     </problem>


### PR DESCRIPTION
[FEDX-173](https://openedx.atlassian.net/browse/FEDX-173)

The adds the support to separate multiple questions in a single CAPA problem. This is needed so that we can identify individual questions to apply accessibility programmatically.