### PR TITLE
Update textual equivalent for status icon

### DIFF
--- a/edx_jsme/templates/jsmeinput.html
+++ b/edx_jsme/templates/jsmeinput.html
@@ -41,7 +41,7 @@
     <br/>
     <p id="answer_${id}" class="answer"></p>
 
-    <p class="status">
+    <p class="status"><span class="sr">
       % if status == 'unsubmitted':
       unanswered
       % elif status == 'correct':
@@ -51,7 +51,7 @@
       % elif status == 'incomplete':
       incomplete
       % endif
-    </p>
+    </span></p>
     <br/> <br/>
 
     <div class="error_message" style="padding: 5px 5px 5px 5px; background-color:#FA6666; height:60px;width:400px; display: none"></div>


### PR DESCRIPTION
Mark with "sr" text to be screen-reader only.

With changes that are being made to capa feedback (see https://github.com/edx/edx-platform/pull/13293), text in "status" is no longer displayed off-screen (legacy CSS had "text-indentation: 100%"). In order to achieve the same goal of providing a textual equivalent for screen-reader users, it is necessary to use the "sr" class.

Here is a screenshot of this change working against our branch with these changes:
![image](https://cloud.githubusercontent.com/assets/484484/18183520/c57576ac-7062-11e6-8aa8-7c0f5cab7f2d.png)

And this comment shows how it looked before the change:
https://github.com/edx/edx-platform/pull/13293#issuecomment-244139850

@natea and @alisan617 can you please review? 