### PR TITLE
Update classes and structure of correctness marker

### DIFF
--- a/edx_jsme/templates/jsmeinput.html
+++ b/edx_jsme/templates/jsmeinput.html
@@ -41,17 +41,12 @@
     <br/>
     <p id="answer_${id}" class="answer"></p>
 
-    <p class="status"><span class="sr">
-      % if status == 'unsubmitted':
-      unanswered
-      % elif status == 'correct':
-      correct
-      % elif status == 'incorrect':
-      incorrect
-      % elif status == 'incomplete':
-      incomplete
-      % endif
-    </span></p>
+    <div class="indicator-container">
+        <span class="status ${status.classname}" data-tooltip="${status.display_tooltip}">
+            <span class="sr">${status.display_name}</span>
+            <span class="status-icon" aria-hidden="true"></span>
+        </span>
+    </div>
     <br/> <br/>
 
     <div class="error_message" style="padding: 5px 5px 5px 5px; background-color:#FA6666; height:60px;width:400px; display: none"></div>


### PR DESCRIPTION
Fairly recent changes to how the "correctness" icons are shown on capa problems caused JSME to no longer show correctness indicators (the CSS changed). I have updated the JSME template so the correctness indicator (and tooltip) shows again.

![image](https://cloud.githubusercontent.com/assets/484484/21455826/694435d4-c8f1-11e6-8a0a-a58fc41ff802.png)

![image](https://cloud.githubusercontent.com/assets/484484/21455876/cf371960-c8f1-11e6-9cc9-be0da3bc1978.png)

@cguardia if you could please take a look and merge this PR, I will take care of updating the JSME version in edx-platform.

@staubina, please also review
