### PR TITLE
WIP: Move CAPA library to xblock_capa

### DIFF
--- a/edx_jsme/__init__.py
+++ b/edx_jsme/__init__.py
@@ -4,8 +4,8 @@ Adds input and response types for JSME problems.
 import json
 import re
 
-from capa import inputtypes, responsetypes
-from capa.correctmap import CorrectMap
+from xblock_capa.lib import inputtypes, responsetypes
+from xblock_capa.lib.correctmap import CorrectMap
 from django.utils.translation import ugettext as _
 
 


### PR DESCRIPTION
As part of https://github.com/edx/edx-platform/pull/19071, we are moving the `common/lib/capa` code underneath the new `openedx.core.lib.xblock_builtin.xblock_capa.lib`.  The CAPA library code itself will remain unchanged.

Please let me know if you have any questions or concerns?

**JIRA tickets**:  LX-74

**Discussions**: See [PR#19071 comments](https://github.com/edx/edx-platform/pull/19071#issuecomment-459398584)

**Dependencies**: https://github.com/edx/edx-platform/pull/19071

**Sandbox URL**: See https://github.com/edx/edx-platform/pull/19071

**Testing instructions**:

TBD

**Author notes and concerns**:

1. We are currently re-working https://github.com/edx/edx-platform/pull/19071 to accommodate the move of the CAPA library, and so this change may not be required.

**Reviewers**
- [ ] OpenCraft internal reviewer's TBD