### PR TITLE
refactor: use capa from xmodule instead of common/lib

### DIFF
--- a/edx_jsme/__init__.py
+++ b/edx_jsme/__init__.py
@@ -4,8 +4,8 @@ Adds input and response types for JSME problems.
 import json
 import re
 
-from capa import inputtypes, responsetypes
-from capa.correctmap import CorrectMap
+from xmodule.capa import inputtypes, responsetypes
+from xmodule.capa.correctmap import CorrectMap
 from django.utils.translation import ugettext as _
 
 


### PR DESCRIPTION
This PR is a part of https://github.com/openedx/edx-platform/pull/30403 and needs to be merged before that PR